### PR TITLE
chore: update action to new repository location

### DIFF
--- a/.github/workflows/import-secrets.yml
+++ b/.github/workflows/import-secrets.yml
@@ -33,7 +33,7 @@ jobs:
             ${{ inputs.secrets }}
 
       - name: Write to Github
-        uses: google/secrets-sync-action@v1.7.0
+        uses: jpoehnelt/secrets-sync-action@v1.7.0
         with:
           secrets: |
             ^AWS_.*

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -12,7 +12,7 @@ jobs:
       BN_GITHUB_TOKEN: ${{ secrets.BN_GITHUB_TOKEN }}
     steps:
       - name: Set secrets from this repo and organization
-        uses: google/secrets-sync-action@v1.7.1
+        uses: jpoehnelt/secrets-sync-action@v1.7.1
         with:
           secrets: |
             ^VAULT_.*


### PR DESCRIPTION
This is a PR to update the action to the new repository location from https://github.com/google/secrets-sync-action to https://github.com/jpoehnelt/secrets-sync-action. Note that GitHub does redirect the old repository to the new one, so this is more housekeeping than anything else.