### PR TITLE
fix(ci): serialize secrets-sync writes to fix 'Requires authentication' 401s

### DIFF
--- a/.github/workflows/import-secrets.yml
+++ b/.github/workflows/import-secrets.yml
@@ -48,3 +48,8 @@ jobs:
             ${{ github.repository }}
           dry_run: false
           github_token: ${{ env.BN_GITHUB_TOKEN }}
+          # Fine-grained PATs (github_pat_) hit GitHub's stricter secondary
+          # rate limit under parallel secret writes, surfacing as
+          # "HttpError: Requires authentication". Serialize the writes.
+          concurrency: "1"
+          retries: "5"


### PR DESCRIPTION
Set secrets-sync `concurrency: 1` (+ `retries: 5`) — fine-grained BN_GITHUB_TOKEN trips GitHub's secondary rate limit under parallel secret writes, surfacing as intermittent 401 Requires authentication.